### PR TITLE
feat-cadastro de pessoas

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import "./styles/globals.css";
 
+import Pessoa from "./pages/Pessoa"
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
@@ -32,6 +33,11 @@ function App() {
         <Route path="/alunos" element={
           <ProtectedRoute>
             <Alunos />
+          </ProtectedRoute>
+        } />
+          <Route path="/pessoas" element={
+          <ProtectedRoute>
+            <Pessoa />
           </ProtectedRoute>
         } />
         <Route path="/planos" element={

--- a/frontend/src/components/ModalCadastroPessoa.jsx
+++ b/frontend/src/components/ModalCadastroPessoa.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { X, UserPlus } from "lucide-react";
+import { X, UserPlus, GraduationCap, Briefcase } from "lucide-react";
 import "../styles/modal_cadastro_pessoa.css";
 
 export default function ModalCadastroPessoa({
@@ -10,148 +10,270 @@ export default function ModalCadastroPessoa({
   onClose,
   onSave,
   textoBotao = "Salvar",
-  mostrarPlano = false,
-  mostrarCargo = false,
   planos = [],
 }) {
+  
+  const handleCheckboxAluno = (checked) => {
+    setDados({
+      ...dados,
+      isAluno: checked,
+      plano_id: checked ? dados.plano_id : "",
+      status: checked ? dados.status : "Ativo",
+      dataMatricula: checked ? dados.dataMatricula : "",
+    });
+  };
+
+  const handleCheckboxFuncionario = (checked) => {
+    setDados({
+      ...dados,
+      isFuncionario: checked,
+      cargo: checked ? dados.cargo : "",
+      dataAdmissao: checked ? dados.dataAdmissao : "",
+      salario: checked ? dados.salario : "",
+      comissao: checked ? dados.comissao : "",
+    });
+  };
+
   return (
     <div className="modal-overlay">
-      <div className="modal modal-form">
-        <div className="modal-header">
-          <h2>
-            {icone}
-            {titulo}
-          </h2>
+      <div className="modal-container-layout">
+        
+        {/* MODAL PRINCIPAL - Agora com controle de rolagem próprio se necessário */}
+        <div className="modal modal-form">
+          <div className="modal-header">
+            <h2>
+              {icone}
+              {titulo}
+            </h2>
 
-          <button className="modal-close" onClick={onClose}>
-            <X size={18} />
-          </button>
-        </div>
-
-        <div className="modal-grid">
-          <div className="input-group">
-            <label>Nome completo *</label>
-            <input
-              value={dados.nome}
-              onChange={(e) => setDados({ ...dados, nome: e.target.value })}
-              placeholder="Ex: Maria Silva"
-            />
+            <button className="modal-close" onClick={onClose}>
+              <X size={18} />
+            </button>
           </div>
 
-          <div className="input-group">
-            <label>CPF *</label>
-            <input
-              value={dados.cpf}
-              onChange={(e) => setDados({ ...dados, cpf: e.target.value })}
-              placeholder="Ex: 123.456.789-00"
-            />
-          </div>
-
-          <div className="input-group">
-            <label>E-mail *</label>
-            <input
-              type="email"
-              value={dados.email}
-              onChange={(e) => setDados({ ...dados, email: e.target.value })}
-              placeholder="Ex: maria@email.com"
-            />
-          </div>
-
-          <div className="input-group">
-            <label>Telefone *</label>
-            <input
-              value={dados.telefone}
-              onChange={(e) => setDados({ ...dados, telefone: e.target.value })}
-              placeholder="Ex: (11) 99999-9999"
-            />
-          </div>
-
-          <div className="input-group">
-            <label>Data de nascimento *</label>
-            <input
-              type="date"
-              value={dados.dataNascimento}
-              onChange={(e) =>
-                setDados({ ...dados, dataNascimento: e.target.value })
-              }
-            />
-          </div>
-
-          <div className="input-group">
-            <label>Endereço *</label>
-            <input
-              value={dados.endereco}
-              onChange={(e) => setDados({ ...dados, endereco: e.target.value })}
-              placeholder="Ex: Rua das Flores, 123"
-            />
-          </div>
-
-          {mostrarPlano && (
+          <div className="modal-grid">
             <div className="input-group">
-              <label>Plano *</label>
-              <select
-                value={dados.plano_id || ""}
+              <label>Nome completo *</label>
+              <input
+                value={dados.nome || ""}
+                onChange={(e) => setDados({ ...dados, nome: e.target.value })}
+                placeholder="Ex: Maria Silva"
+              />
+            </div>
+
+            <div className="input-group">
+              <label>CPF *</label>
+              <input
+                value={dados.cpf || ""}
+                onChange={(e) => setDados({ ...dados, cpf: e.target.value })}
+                placeholder="Ex: 123.456.789-00"
+              />
+            </div>
+
+            <div className="input-group">
+              <label>E-mail *</label>
+              <input
+                type="email"
+                value={dados.email || ""}
+                onChange={(e) => setDados({ ...dados, email: e.target.value })}
+                placeholder="Ex: maria@email.com"
+              />
+            </div>
+
+            <div className="input-group">
+              <label>Telefone *</label>
+              <input
+                value={dados.telefone || ""}
+                onChange={(e) => setDados({ ...dados, telefone: e.target.value })}
+                placeholder="Ex: (11) 99999-9999"
+              />
+            </div>
+
+            <div className="input-group">
+              <label>Data de nascimento *</label>
+              <input
+                type="date"
+                value={dados.dataNascimento || ""}
                 onChange={(e) =>
-                  setDados({ ...dados, plano_id: e.target.value })
+                  setDados({ ...dados, dataNascimento: e.target.value })
                 }
-              >
-                <option value="">Selecione um plano</option>
-                {planos.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.nome_plano}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
-          )}
 
-          {mostrarCargo && (
             <div className="input-group">
-              <label>Cargo *</label>
-              <select
-                value={dados.cargo}
-                onChange={(e) => setDados({ ...dados, cargo: e.target.value })}
-              >
-                <option value="">Selecione um cargo</option>
-                <option value="Professor">Professor</option>
-                <option value="Recepcionista">Recepcionista</option>
-                <option value="Gerente">Gerente</option>
-              </select>
+              <label>Endereço *</label>
+              <input
+                value={dados.endereco || ""}
+                onChange={(e) => setDados({ ...dados, endereco: e.target.value })}
+                placeholder="Ex: Rua das Flores, 123"
+              />
             </div>
-          )}
 
-          <div className="input-group">
-            <label>Status *</label>
-            <select
-              value={dados.status}
-              onChange={(e) => setDados({ ...dados, status: e.target.value })}
-            >
-              <option value="Ativo">Ativo</option>
-              <option value="Inativo">Inativo</option>
-              <option value="Cancelado">Cancelado</option>
-            </select>
+            <div className="input-group input-full">
+              <label>Senha *</label>
+              <input
+                type="password"
+                value={dados.senha || ""}
+                onChange={(e) => setDados({ ...dados, senha: e.target.value })}
+                placeholder="Digite uma senha"
+              />
+            </div>
+
+            <div className="vinculos-section input-full">
+              <div className="vinculo-divider">
+                <GraduationCap size={16} />
+                <span>VÍNCULO COMO ALUNO</span>
+              </div>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={!!dados.isAluno}
+                  onChange={(e) => handleCheckboxAluno(e.target.checked)}
+                />
+                Esta pessoa é aluna
+              </label>
+
+              <div className="vinculo-divider">
+                <Briefcase size={16} />
+                <span>VÍNCULO COMO FUNCIONÁRIO</span>
+              </div>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={!!dados.isFuncionario}
+                  onChange={(e) => handleCheckboxFuncionario(e.target.checked)}
+                />
+                Esta pessoa é funcionária
+              </label>
+            </div>
           </div>
 
-          <div className="input-group input-full">
-            <label>Senha *</label>
-            <input
-              type="password"
-              value={dados.senha}
-              onChange={(e) => setDados({ ...dados, senha: e.target.value })}
-              placeholder="Digite uma senha"
-            />
+          <div className="modal-footer">
+            <button className="btn btn--outline" onClick={onClose}>
+              Cancelar
+            </button>
+
+            <button className="btn btn--primary" onClick={onSave}>
+              {textoBotao}
+            </button>
           </div>
         </div>
 
-        <div className="modal-footer">
-          <button className="btn btn--outline" onClick={onClose}>
-            Cancelar
-          </button>
+        {/* COLUNA INDEPENDENTE DOS MODAIS SECUNDÁRIOS */}
+        {(dados.isAluno || dados.isFuncionario) && (
+          <div className="modal-satellites-column">
+            
+            {/* INFORMAÇÕES DO ALUNO */}
+            {dados.isAluno && (
+              <div className="modal-satellite-card">
+                <div className="satellite-header">
+                  <h3>
+                    <GraduationCap size={16} />
+                    Informações do Aluno
+                  </h3>
+                </div>
+                
+                <div className="satellite-body">
+                  <div className="input-group">
+                    <label>Plano *</label>
+                    <select
+                      value={dados.plano_id || ""}
+                      onChange={(e) =>
+                        setDados({ ...dados, plano_id: e.target.value })
+                      }
+                    >
+                      <option value="">Selecione um plano</option>
+                      {planos.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.nome_plano}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
 
-          <button className="btn btn--primary" onClick={onSave}>
-            {textoBotao}
-          </button>
-        </div>
+                  <div className="input-group">
+                    <label>Status *</label>
+                    <select
+                      value={dados.status || "Ativo"}
+                      onChange={(e) => setDados({ ...dados, status: e.target.value })}
+                    >
+                      <option value="Ativo">Ativo</option>
+                      <option value="Inativo">Inativo</option>
+                      <option value="Cancelado">Cancelado</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>Data de matrícula</label>
+                    <input
+                      type="date"
+                      value={dados.dataMatricula || ""}
+                      onChange={(e) => setDados({ ...dados, dataMatricula: e.target.value })}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* INFORMAÇÕES DO FUNCIONÁRIO */}
+            {dados.isFuncionario && (
+              <div className="modal-satellite-card">
+                <div className="satellite-header">
+                  <h3>
+                    <Briefcase size={16} />
+                    Informações do Funcionário
+                  </h3>
+                </div>
+                
+                <div className="satellite-body">
+                  <div className="input-group">
+                    <label>Cargo *</label>
+                    <select
+                      value={dados.cargo || ""}
+                      onChange={(e) => setDados({ ...dados, cargo: e.target.value })}
+                    >
+                      <option value="">Selecione um cargo</option>
+                      <option value="Professor">Professor</option>
+                      <option value="Recepcionista">Recepcionista</option>
+                      <option value="Gerente">Gerente</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>Data de admissão *</label>
+                    <input
+                      type="date"
+                      value={dados.dataAdmissao || ""}
+                      onChange={(e) => setDados({ ...dados, dataAdmissao: e.target.value })}
+                    />
+                  </div>
+
+                  <div className="input-group">
+                    <label>Salário (R$) *</label>
+                    <input
+                      type="text"
+                      value={dados.salario || ""}
+                      onChange={(e) => setDados({ ...dados, salario: e.target.value })}
+                      placeholder="Ex: 2.500,00"
+                    />
+                  </div>
+
+                  <div className="input-group">
+                    <label>Comissão (%)</label>
+                    <input
+                      type="text"
+                      value={dados.comissao || ""}
+                      onChange={(e) => setDados({ ...dados, comissao: e.target.value })}
+                      placeholder="Ex: 5"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+          </div>
+        )}
+
       </div>
     </div>
   );

--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -18,6 +18,7 @@ import {
   Briefcase,
   Pencil,
   X,
+  User,
 } from "lucide-react";
 
 import "./Sidebar.css";
@@ -35,6 +36,12 @@ const NAV_ITEMS = [
     label: "Alunos",
     path: "/Alunos",
     icon: <Users size={18} />,
+  },
+  {
+    id: "pessoa",
+    label: "Pessoas",
+    path: "/pessoas",
+    icon: <User size={18} />,
   },
 
   {

--- a/frontend/src/pages/Pessoa.jsx
+++ b/frontend/src/pages/Pessoa.jsx
@@ -1,0 +1,524 @@
+import React, { useMemo, useState, useEffect } from "react";
+import Sidebar from "../layout/Sidebar";
+import ModalCadastroPessoa from "../components/ModalCadastroPessoa";
+import ModalPerfil from "../components/ModalPerfil";
+import "../styles/alunos.css";
+import "../styles/globals.css";
+
+import {
+  Plus,
+  Search,
+  Users,
+  TrendingUp,
+  CircleX,
+  Pencil,
+  Trash2,
+  X,
+  AlertTriangle,
+} from "lucide-react";
+
+const ENDPOINT_API = "http://localhost:3002/api/pessoas";
+
+const payloadInicial = {
+  nome: "",
+  cpf: "",
+  telefone: "",
+  email: "",
+  dataNascimento: "",
+  endereco: "",
+  plano_id: "",
+  status: "Ativo",
+  matricula: "",
+  senha: "",
+  isAluno: false,
+  isFuncionario: false,
+  dataMatricula: "",
+  cargo: "",
+  dataAdmissao: "",
+  salario: "",
+  comissao: "",
+};
+
+export default function Pessoa() {
+  const [listaPessoas, setListaPessoas] = useState([]);
+  const [listaPlanos, setListaPlanos] = useState([]);
+  const [termoPesquisa, setTermoPesquisa] = useState("");
+
+  const [indicadores, setIndicadores] = useState({
+    total: 0,
+    novosMes: 0,
+    cancelamentos: 0,
+    crescimento: 0,
+  });
+
+  const [filtroAtual, setFiltroAtual] = useState("Todos");
+  const [isModalInclusaoAberto, setIsModalInclusaoAberto] = useState(false);
+  const [dadosNovoRegistro, setDadosNovoRegistro] = useState(payloadInicial);
+  const [isModalEdicaoAberto, setIsModalEdicaoAberto] = useState(false);
+  const [registroSelecionadoEdicao, setRegistroSelecionadoEdicao] = useState(null);
+  const [isModalRemocaoAberto, setIsModalRemocaoAberto] = useState(false);
+  const [registroSelecionadoRemocao, setRegistroSelecionadoRemocao] = useState(null);
+
+  useEffect(() => {
+    obterDadosIniciais();
+  }, []);
+
+  async function obterDadosIniciais() {
+    try {
+      const [respostaPessoas, respostaContagem, respostaPlanos] = await Promise.all([
+        fetch(`${ENDPOINT_API}?tipo=aluno`),
+        fetch(`${ENDPOINT_API}/total-alunos`),
+        fetch(`${ENDPOINT_API}/planos`),
+      ]);
+
+      const dadosPessoas = await respostaPessoas.json();
+      const dadosContagem = await respostaContagem.json();
+      const dadosPlanos = await respostaPlanos.json();
+
+      setListaPessoas(Array.isArray(dadosPessoas) ? dadosPessoas : []);
+      setListaPlanos(Array.isArray(dadosPlanos) ? dadosPlanos : []);
+
+      setIndicadores((estadoAnterior) => ({
+        ...estadoAnterior,
+        total: dadosContagem.totalAlunos || 0,
+      }));
+    } catch (erro) {
+      console.error("Erro ao carregar dados:", erro);
+      setListaPessoas([]);
+      setListaPlanos([]);
+    }
+  }
+
+  async function atualizarRegistros() {
+    try {
+      const resposta = await fetch(`${ENDPOINT_API}?tipo=aluno`);
+      const dados = await resposta.json();
+      setListaPessoas(Array.isArray(dados) ? dados : []);
+    } catch (erro) {
+      console.error("Erro ao recarregar alunos:", erro);
+      setListaPessoas([]);
+    }
+  }
+
+  const dadosFiltrados = useMemo(() => {
+    return listaPessoas.filter((item) => {
+      const buscaMinusculo = termoPesquisa.toLowerCase();
+
+      const atendeBusca =
+        (item.nome || "").toLowerCase().includes(buscaMinusculo) ||
+        (item.cpf || "").includes(termoPesquisa) ||
+        (item.email || "").toLowerCase().includes(buscaMinusculo);
+
+      const atendeFiltro =
+        filtroAtual === "Todos" || item.status === filtroAtual;
+
+      return atendeBusca && atendeFiltro;
+    });
+  }, [listaPessoas, termoPesquisa, filtroAtual]);
+
+  async function ejecutarInclusao() {
+    try {
+      const resposta = await fetch(ENDPOINT_API, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(dadosNovoRegistro),
+      });
+
+      const resultado = await resposta.json();
+
+      if (!resposta.ok) {
+        console.error(resultado);
+        alert("Erro ao salvar aluno");
+        return;
+      }
+
+      alert("Aluno cadastrado com sucesso!");
+      await atualizarRegistros();
+
+      setDadosNovoRegistro(payloadInicial);
+      setIsModalInclusaoAberto(false);
+    } catch (erro) {
+      console.error(erro.response?.data || erro);
+      alert("Já existe uma pessoa cadastrada com este CPF.");
+    }
+  }
+
+  function dispararEdicao(item) {
+    // Inicializa as flags de Aluno/Funcionário baseado nos dados vindos do backend
+    setRegistroSelecionadoEdicao({
+      ...item,
+      isAluno: !!item.plano_id || item.isAluno || false,
+      isFuncionario: !!item.cargo || item.isFuncionario || false,
+      status: item.status_assinatura || item.status || "Ativo",
+      dataNascimento: item.dataNascimento || item.data_nascimento || "",
+    });
+    setIsModalEdicaoAberto(true);
+  }
+
+  async function executarEdicao() {
+    if (!registroSelecionadoEdicao) return;
+
+    try {
+      const resposta = await fetch(`${ENDPOINT_API}/${registroSelecionadoEdicao.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          nome: registroSelecionadoEdicao.nome,
+          cpf: registroSelecionadoEdicao.cpf,
+          telefone: registroSelecionadoEdicao.telefone,
+          email: registroSelecionadoEdicao.email,
+          dataNascimento: registroSelecionadoEdicao.dataNascimento,
+          endereco: registroSelecionadoEdicao.endereco,
+          senha: registroSelecionadoEdicao.senha,
+          // Propriedades fragmentadas enviadas de forma íntegra para o back-end
+          isAluno: registroSelecionadoEdicao.isAluno,
+          plano_id: registroSelecionadoEdicao.isAluno ? registroSelecionadoEdicao.plano_id : null,
+          status: registroSelecionadoEdicao.isAluno ? registroSelecionadoEdicao.status : "Ativo",
+          dataMatricula: registroSelecionadoEdicao.isAluno ? registroSelecionadoEdicao.dataMatricula : null,
+          isFuncionario: registroSelecionadoEdicao.isFuncionario,
+          cargo: registroSelecionadoEdicao.isFuncionario ? registroSelecionadoEdicao.cargo : null,
+          dataAdmissao: registroSelecionadoEdicao.isFuncionario ? registroSelecionadoEdicao.dataAdmissao : null,
+          salario: registroSelecionadoEdicao.isFuncionario ? registroSelecionadoEdicao.salario : null,
+          comissao: registroSelecionadoEdicao.isFuncionario ? registroSelecionadoEdicao.comissao : null,
+        }),
+      });
+
+      const resultado = await resposta.json();
+
+      if (!resposta.ok) {
+        console.error(resultado);
+        alert("Erro ao editar aluno");
+        return;
+      }
+
+      alert("Alterações salvas com sucesso!");
+      await atualizarRegistros();
+      setIsModalEdicaoAberto(false);
+      setRegistroSelecionadoEdicao(null);
+    } catch (erro) {
+      console.error("Erro ao editar aluno:", erro);
+      alert("Erro de conexão com o servidor");
+    }
+  }
+
+  function dispararRemocao(item) {
+    setRegistroSelecionadoRemocao(item);
+    setIsModalRemocaoAberto(true);
+  }
+
+  async function executarRemocao() {
+    if (!registroSelecionadoRemocao) return;
+
+    try {
+      const resposta = await fetch(`${ENDPOINT_API}/${registroSelecionadoRemocao.id}`, {
+        method: "DELETE",
+      });
+
+      if (!resposta.ok) {
+        const erroObtido = await resposta.json();
+        console.error("Erro ao excluir aluno:", erroObtido);
+        alert(erroObtido.erro || "Erro ao excluir aluno");
+        return;
+      }
+
+      setListaPessoas((estadoAnterior) => estadoAnterior.filter((item) => item.id !== registroSelecionadoRemocao.id));
+      setIsModalRemocaoAberto(false);
+      setRegistroSelecionadoRemocao(null);
+    } catch (erro) {
+      console.error("Erro ao excluir aluno:", erro);
+      alert("Erro de conexão com o servidor");
+    }
+  }
+
+  function converterData(valor) {
+    if (!valor) return "-";
+    if (valor.includes("/")) return valor;
+
+    const [ano, mes, dia] = valor.split("-");
+    if (!ano || !mes || !dia) return valor;
+
+    return `${dia.slice(0, 2)}/${mes}/${ano}`;
+  }
+
+  function extrairIniciais(nomeCompleto = "") {
+    return nomeCompleto
+      .split(" ")
+      .filter(Boolean)
+      .map((palavra) => palavra[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }
+
+  return (
+    <div className="alunos-layout">
+      <Sidebar />
+
+      <main className="alunos-page">
+        <header className="alunos-header">
+          <div>
+            <h1>Cadastro de Pessoas</h1>
+            <p>Cadastro de pessoas para a acadêmia</p>
+          </div>
+
+          <button
+            className="btn btn--primary"
+            onClick={() => setIsModalInclusaoAberto(true)}
+          >
+            <Plus size={17} />
+            Nova Pessoa
+          </button>
+        </header>
+
+        <section className="stats-grid">
+          <article className="stat-card">
+            <div className="stat-icon stat-blue">
+              <Users size={22} />
+            </div>
+            <div>
+              <span>Total Registrado</span>
+              <strong>{indicadores.total}</strong>
+            </div>
+          </article>
+
+          <article className="stat-card">
+            <div className="stat-icon stat-green">
+              <TrendingUp size={22} />
+            </div>
+            <div>
+              <span>Novos este mês</span>
+              <strong>{indicadores.novosMes}</strong>
+              <small className="positivo">↑ 12% vs. mês anterior</small>
+            </div>
+          </article>
+
+          <article className="stat-card">
+            <div className="stat-icon stat-red">
+              <CircleX size={22} />
+            </div>
+            <div>
+              <span>Cancelamentos</span>
+              <strong>{indicadores.cancelamentos}</strong>
+              <small className="negativo">↑ 50% vs. mês anterior</small>
+            </div>
+          </article>
+
+          <article className="stat-card">
+            <div className="stat-icon stat-green">
+              <TrendingUp size={22} />
+            </div>
+            <div>
+              <span>Taxa de Crescimento</span>
+              <strong>+{indicadores.crescimento}%</strong>
+              <small className="positivo">↑ 8% vs. mês anterior</small>
+            </div>
+          </article>
+        </section>
+
+        <section className="alunos-content">
+          <div className="toolbar">
+            <div className="search-box">
+              <Search size={18} />
+              <input
+                type="text"
+                placeholder="Buscar por nome, CPF ou e-mail..."
+                value={termoPesquisa}
+                onChange={(e) => setTermoPesquisa(e.target.value)}
+              />
+            </div>
+
+            <div className="filters">
+              {["Todos", "Ativo", "Inadimplente", "Cancelado"].map(
+                (status) => (
+                  <button
+                    key={status}
+                    className={filtroAtual === status ? "active" : ""}
+                    onClick={() => setFiltroAtual(status)}
+                  >
+                    {status === "Ativo" ? "Ativos" : status}
+                  </button>
+                )
+              )}
+            </div>
+          </div>
+
+          <div className="table-wrapper">
+            <table className="alunos-table">
+              <thead>
+                <tr>
+                  <th>Ações</th>
+                  <th>Nome</th>
+                  <th>CPF</th>
+                  <th>Telefone</th>
+                  <th>E-mail</th>
+                  <th>Data Nascimento</th>
+                  <th>Endereço</th>
+                  <th>Matrícula</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                ={dadosFiltrados.map((pessoa) => (
+                  <tr key={pessoa.id}>
+                    <td>
+                      <div className="table-actions">
+                        <button
+                          className="action-btn edit"
+                          onClick={() => dispararEdicao(pessoa)}
+                          title="Editar cadastro"
+                        >
+                          <Pencil size={15} />
+                        </button>
+
+                        <button
+                          className="action-btn delete"
+                          onClick={() => dispararRemocao(pessoa)}
+                          title="Excluir cadastro"
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    </td>
+
+                    <td>
+                      <div className="student-cell">
+                        <div className="avatar">{extrairIniciais(pessoa.nome)}</div>
+                        <span>{pessoa.nome}</span>
+                      </div>
+                    </td>
+
+                    <td>{pessoa.cpf}</td>
+                    <td>{pessoa.telefone}</td>
+                    <td>{pessoa.email}</td>
+                    <td>
+                      {converterData(
+                        pessoa.dataNascimento ||
+                        pessoa.data_nascimento
+                      )}
+                    </td>
+                    <td className="address-cell">{pessoa.endereco}</td>
+                    <td>{converterData(pessoa.matricula)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <footer className="table-footer">
+            <span>
+              Mostrando 1 a {dadosFiltrados.length} de {listaPessoas.length} pessoas
+            </span>
+
+            <div className="pagination">
+              <button>‹</button>
+              <button className="active">1</button>
+              <button>2</button>
+              <button>3</button>
+              <button>...</button>
+              <button>50</button>
+              <button>›</button>
+            </div>
+          </footer>
+        </section>
+      </main>
+
+      {/* MODAL PARA CRIAÇÃO */}
+      {isModalInclusaoAberto && (
+        <ModalCadastroPessoa
+          titulo="Novo Registro"
+          dados={dadosNovoRegistro}
+          setDados={setDadosNovoRegistro}
+          onClose={() => setIsModalInclusaoAberto(false)}
+          onSave={executarInclusao}
+          textoBotao="Salvar"
+          planos={listaPlanos}
+        />
+      )}
+
+      {/* MODAL NOVO APLICADO PARA EDICAO */}
+      {isModalEdicaoAberto && registroSelecionadoEdicao && (
+        <ModalCadastroPessoa
+          titulo="Editar Informações"
+          icone={<Pencil size={18} />}
+          dados={registroSelecionadoEdicao}
+          setDados={setRegistroSelecionadoEdicao}
+          onClose={() => {
+            setIsModalEdicaoAberto(false);
+            setRegistroSelecionadoEdicao(null);
+          }}
+          onSave={executarEdicao}
+          textoBotao="Salvar alterações"
+          planos={listaPlanos}
+        />
+      )}
+
+      {/* MODAL REMOÇÃO */}
+      {isModalRemocaoAberto && registroSelecionadoRemocao && (
+        <div className="modal-overlay">
+          <div className="modal delete-modal">
+            <div className="modal-header">
+              <h2>
+                <Trash2 size={18} />
+                Excluir Cadastro
+              </h2>
+
+              <button
+                className="modal-close"
+                onClick={() => setIsModalRemocaoAberto(false)}
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="alert-box">
+              <AlertTriangle size={20} />
+              <div>
+                <strong>Atenção!</strong>
+                <p>Esta ação não poderá ser desfeita.</p>
+              </div>
+            </div>
+
+            <p className="delete-question">Deseja excluir este registro?</p>
+
+            <div className="delete-info">
+              <strong>{registroSelecionadoRemocao.nome}</strong>
+              <div>
+                <span>CPF: {registroSelecionadoRemocao.cpf}</span>
+                <span>Plano: {registroSelecionadoRemocao.plano || "-"}</span>
+                <span>Status: {registroSelecionadoRemocao.status_assinatura || "-"}</span>
+                <span>Matrícula: {registroSelecionadoRemocao.matricula}</span>
+                <span>
+                  Nascimento:{" "}
+                  {converterData(
+                    registroSelecionadoRemocao.dataNascimento ||
+                    registroSelecionadoRemocao.data_nascimento
+                  )}
+                </span>
+                <span>E-mail: {registroSelecionadoRemocao.email}</span>
+                <span>Telefone: {registroSelecionadoRemocao.telefone}</span>
+                <span>Endereço: {registroSelecionadoRemocao.endereco}</span>
+              </div>
+            </div>
+
+            <div className="modal-footer">
+              <button
+                className="btn btn--outline"
+                onClick={() => setIsModalRemocaoAberto(false)}
+              >
+                Cancelar
+              </button>
+
+              <button className="btn btn--danger" onClick={executarRemocao}>
+                Excluir permanentemente
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/modal_cadastro_pessoa.css
+++ b/frontend/src/styles/modal_cadastro_pessoa.css
@@ -1,151 +1,103 @@
-/* =========================================================
-   MODAL CADASTRO PESSOA
-   ========================================================= */
-
-/* OVERLAY */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.6);
-  backdrop-filter: blur(4px);
-
+/* Container flexível geral que alinha o modal central e o bloco lateral */
+.modal-container-layout {
   display: flex;
-  align-items: center;
-  justify-content: center;
-
-  z-index: 99999; /* MUITO IMPORTANTE */
+  align-items: flex-start;
+  gap: 20px;
+  max-height: 95vh;
+  padding: 10px;
 }
 
-/* CONTAINER */
-.modal {
-  background: var(--color-bg-surface);
-  border-radius: var(--radius-xl);
-  width: 580px;
-  max-width: calc(100% - 32px);
+/* O modal principal agora pode se manter fixo */
+.modal.modal-form {
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+/* COLUNA LATERAL - Roda de forma totalmente independente e esconde a barra */
+.modal-satellites-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 340px; 
+  max-height: 90vh;      /* Define uma altura máxima igual ao do modal principal */
+  overflow-y: auto;      /* Permite a rolagem interna e isolada dos cards secundários */
+  padding-right: 4px;    /* Margem de segurança interna */
+  animation: fadeInRight 0.25s ease-out;
+
+  /* Remove a barra de rolagem no Firefox */
+  scrollbar-width: none; 
+  /* Remove a barra de rolagem no IE/Edge antigo */
+  -ms-overflow-style: none; 
+}
+
+/* Oculta a barra de rolagem para navegadores baseados em Webkit (Chrome, Safari, Edge Novo) */
+.modal-satellites-column::-webkit-scrollbar {
+  display: none;
+  width: 0 !important;
+  height: 0 !important;
+  background: transparent;
+}
+
+/* Cartões individuais da lateral */
+.modal-satellite-card {
+  background: #ffffff;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   padding: 20px;
-  border: 1px solid var(--color-border);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-  animation: modalFade 0.2s ease;
+  width: 100%;
+  flex-shrink: 0; /* Impede que os cards fiquem esmagados se faltar espaço vertical */
 }
 
-/* HEADER */
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.modal-header h2 {
+.satellite-header h3 {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: var(--text-lg);
-  font-weight: var(--fw-semibold);
-  color: var(--color-text-primary);
+  font-size: 15px;
+  color: #1e293b;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 8px;
 }
 
-.modal-close {
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-md);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-text-secondary);
-  transition: var(--transition);
-}
-
-.modal-close:hover {
-  background: var(--gray-100);
-  color: var(--color-text-primary);
-}
-
-/* GRID FORM */
-.modal-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px 16px;
-  margin-top: 18px;
-}
-
-/* INPUT GROUP */
-.input-group {
+.satellite-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 14px;
 }
 
-.input-group label {
-  font-size: var(--text-xs);
-  font-weight: var(--fw-medium);
-  color: var(--color-text-primary);
-}
-
-/* INPUTS */
-.input-group input,
-.input-group select {
-  height: 38px;
-  padding: 0 12px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  outline: none;
-  transition: var(--transition);
-  background: #fff;
-}
-
-.input-group input::placeholder {
-  color: var(--color-text-muted);
-}
-
-/* FOCUS */
-.input-group input:focus,
-.input-group select:focus {
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
-}
-
-/* INPUT FULL */
-.input-full {
-  grid-column: span 2;
-}
-
-/* FOOTER */
-.modal-footer {
+/* Configurações adicionais de layout */
+.vinculo-divider {
   display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 20px;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #64748b;
+  letter-spacing: 0.5px;
+  margin-top: 14px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid #f1f5f9;
+  padding-bottom: 2px;
 }
 
-/* =========================================================
-   ANIMAÇÃO
-   ========================================================= */
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+  user-select: none;
+}
 
-@keyframes modalFade {
+@keyframes fadeInRight {
   from {
     opacity: 0;
-    transform: translateY(-10px) scale(0.97);
+    transform: translateX(15px);
   }
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-/* =========================================================
-   RESPONSIVO
-   ========================================================= */
-
-@media (max-width: 600px) {
-  .modal {
-    padding: 16px;
-  }
-
-  .modal-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .input-full {
-    grid-column: span 1;
+    transform: translateX(0);
   }
 }


### PR DESCRIPTION
Fragmentou modal de cadastro e isola informações de vínculos

- Remove os campos de plano e status do modal principal de pessoas.
- Adiciona seleção de vínculos (aluno/funcionário) acima do botão salvar.
- Cria modais satélites dinâmicos na lateral direita com rolagem independente e sem barra visível.
- Substitui o modal antigo da ação de edição para utilizar o novo componente unificado.